### PR TITLE
Added option to flatten and compile multiple individual files via wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This defines what files this task will process and should contain key:value pair
 
 The key (destination) should be an unique filepath (supports [grunt.template](https://github.com/cowboy/grunt/blob/master/docs/api_template.md)) and the value (source) should be a filepath or an array of filepaths (supports [minimatch](https://github.com/isaacs/minimatch)).
 
-Note: When the value contains an array of multiple filepaths, the contents are concatenated in the order passed.
+Note: As of now, you can use *.{ext} as your destination filename to individually compile each file to the destination directory. Otherwise, when the source contains an array of multiple filepaths, the contents are concatenated in the order passed.
 
 ##### options ```object```
 
@@ -24,6 +24,12 @@ This controls how this task (and its helpers) operate and should contain key:val
 ##### data ```object```
 
 Sets the data passed to ```jade``` during template compilation. Any data can be passed to the template (including ```grunt``` templates).
+
+#### basePath ```string``` (individual only)
+This option adjusts the folder structure when compiled to the destination directory. When not explicitly set, best effort is made to locate the basePath by comparing all source filepaths left to right for a common pattern.
+
+#### flatten ```boolean``` (individual only)
+This option performs a flat compile that dumps all the files into the root of the destination directory, overwriting files if they exist.
 
 #### Config Examples
 
@@ -103,6 +109,22 @@ jade: {
     }
   }
 }
+```
+
+Flatten all files from a nested structure into a single folder:
+
+``` javascript
+jade: {
+  debug: {
+    options: {
+      flatten: true
+    },
+    files: {
+      "my/destination/*.html": ["test.jade", "test2.jade", "deep/nested/jade.jade"]
+    }
+  }
+}
+
 ```
 
 ## Release History

--- a/grunt.js
+++ b/grunt.js
@@ -45,7 +45,8 @@ module.exports = function(grunt) {
           'tmp/jade.html': ['test/fixtures/jade.jade'],
           'tmp/jade2.html': ['test/fixtures/jade2.jade'],
           'tmp/jadeInclude.html': ['test/fixtures/jadeInclude.jade'],
-          'tmp/jadeTemplate.html': ['test/fixtures/jadeTemplate.jade']
+          'tmp/jadeTemplate.html': ['test/fixtures/jadeTemplate.jade'],
+          'tmp/individual/*.html': ['test/fixtures/jade.jade', 'test/fixtures/jade2.jade', 'test/fixtures/level2/jade3.jade']
         },
         options: {
           data: {
@@ -53,7 +54,19 @@ module.exports = function(grunt) {
             year: '<%= grunt.template.today("yyyy") %>'
           }
         }
-      }
+      },
+      flatten: {
+        files: {
+          'tmp/individual_flatten/*.html': ['test/fixtures/jade.jade', 'test/fixtures/jade2.jade', 'test/fixtures/level2/jade3.jade']
+        },
+        options: {
+          flatten: true,
+          data: {
+            test: true,
+            year: '<%= grunt.template.today("yyyy") %>'
+          }
+        }
+      }      
     },
 
 

--- a/test/expected/individual/jade.html
+++ b/test/expected/individual/jade.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>testing</div></div>

--- a/test/expected/individual/jade2.html
+++ b/test/expected/individual/jade2.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>testing 2</div></div>

--- a/test/expected/individual/level2/jade3.html
+++ b/test/expected/individual/level2/jade3.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>testing 3</div></div>

--- a/test/expected/individual_flatten/jade.html
+++ b/test/expected/individual_flatten/jade.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>testing</div></div>

--- a/test/expected/individual_flatten/jade2.html
+++ b/test/expected/individual_flatten/jade2.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>testing 2</div></div>

--- a/test/expected/individual_flatten/jade3.html
+++ b/test/expected/individual_flatten/jade3.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>testing 3</div></div>

--- a/test/fixtures/level2/jade3.jade
+++ b/test/fixtures/level2/jade3.jade
@@ -1,0 +1,4 @@
+#test.test
+  span#data data
+  if test
+    div testing 3

--- a/test/jade_test.js
+++ b/test/jade_test.js
@@ -1,10 +1,11 @@
 var grunt = require('grunt');
+var fs = require('fs');
 
 exports.jade = {
   compile: function(test) {
     'use strict';
 
-    test.expect(4);
+    test.expect(5);
 
     var actual = grunt.file.read('tmp/jade.html');
     var expected = grunt.file.read('test/expected/jade.html');
@@ -21,6 +22,21 @@ exports.jade = {
     actual = grunt.file.read('tmp/jadeTemplate.html');
     expected = grunt.file.read('test/expected/jadeTemplate.html');
     test.equal(expected, actual, 'should compile jade templates to html with grunt template support');
+    
+    actual = fs.readdirSync('tmp/individual').sort();
+    expected = fs.readdirSync('test/expected/individual').sort();
+    test.deepEqual(expected, actual, 'should compile jade templates individually to html files');
+    
+    test.done();
+  },
+  flatten: function(test) {
+    'use strict';
+
+    test.expect(1);
+
+    var actual = fs.readdirSync('tmp/individual_flatten').sort();
+    var expected = fs.readdirSync('test/expected/individual_flatten').sort();
+    test.deepEqual(expected, actual, 'should compile jade templates individually to html files (to flat structure)');
 
     test.done();
   }


### PR DESCRIPTION
Added option to flatten and compile multiple individual files via wildcards. Including tests and an updated readme file. It's all based on `grunt-contrib-coffee`. 
Also I added the `basePath` option.
