### PR TITLE
Allow options.data to be a function in 'jade' task.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -15,6 +15,18 @@ This controls how this task (and its helpers) operate and should contain key:val
 ##### data ```object```
 
 Sets the data passed to ```jade``` during template compilation. Any data can be passed to the template (including ```grunt``` templates).
+This value also might be a function taking source and destination path as arguments and returning a data object. 
+
+```js
+options: {
+  data: function(dest, src) {
+    return {
+      from: src,
+      to: dest
+    };
+  }
+}
+```
 
 ##### data ```pretty```
 

--- a/grunt.js
+++ b/grunt.js
@@ -52,6 +52,19 @@ module.exports = function(grunt) {
             year: '<%= grunt.template.today("yyyy") %>'
           }
         }
+      },
+      compile_dynamic_data: {
+        files: {
+          'tmp/jadeDynamicData.html': ['test/fixtures/jadeDynamicData.jade']
+        },
+        options: {
+          data: function(dest, src) {
+            return {
+              dest: dest,
+              src: src
+            }
+          }
+        }
       }
     },
 

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -24,8 +24,7 @@ module.exports = function(grunt) {
     // TODO: ditch this when grunt v0.4 is released
     this.files = this.files || helpers.normalizeMultiTaskFiles(this.data, this.target);
 
-    var srcFiles;
-    var taskOutput;
+    var srcFiles, taskOutput, data;
 
     this.files.forEach(function(file) {
       srcFiles = grunt.file.expandFiles(file.src);
@@ -33,7 +32,12 @@ module.exports = function(grunt) {
       taskOutput = [];
 
       srcFiles.forEach(function(srcFile) {
-        taskOutput.push(compileJade(srcFile, options, options.data));
+        if (grunt.util._.isFunction(options.data)) {
+          data = options.data.call(null, file.dest, srcFile);
+        } else {
+          data = options.data;
+        }
+        taskOutput.push(compileJade(srcFile, options, data));
       });
 
       if (taskOutput.length > 0) {

--- a/test/expected/jadeDynamicData.html
+++ b/test/expected/jadeDynamicData.html
@@ -1,0 +1,1 @@
+<div id="test">file <code>test/fixtures/jadeDynamicData.jade</code> compiled into <code>tmp/jadeDynamicData.html</code></div>

--- a/test/fixtures/jadeDynamicData.jade
+++ b/test/fixtures/jadeDynamicData.jade
@@ -1,0 +1,5 @@
+#test
+	| file 
+	code #{src}
+	|  compiled into 
+	code #{dest}

--- a/test/jade_test.js
+++ b/test/jade_test.js
@@ -4,7 +4,7 @@ exports.jade = {
   compile: function(test) {
     'use strict';
 
-    test.expect(4);
+    test.expect(5);
 
     var actual = grunt.file.read('tmp/jade.html');
     var expected = grunt.file.read('test/expected/jade.html');
@@ -21,6 +21,10 @@ exports.jade = {
     actual = grunt.file.read('tmp/jadeTemplate.html');
     expected = grunt.file.read('test/expected/jadeTemplate.html');
     test.equal(expected, actual, 'should compile jade templates to html with grunt template support');
+
+    actual = grunt.file.read('tmp/jadeDynamicData.html');
+    expected = grunt.file.read('test/expected/jadeDynamicData.html');
+    test.equal(expected, actual, 'should allow options.data to be a function');
 
     test.done();
   }


### PR DESCRIPTION
Function will be applied for each file in source array.
Function takes 'dest' and 'src' arguments and returns an object.

This would help to pass data values specific to template path,
for example relative URLs for JS/CSS assets.
