### PR TITLE
Improved default processor for JST keys

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,6 @@ module.exports = function(grunt) {
         options: {
           client: true,
           compileDebug: false,
-          processName: function(str) { return str.match(/^test\/fixtures\/(.*)\.jade$/)[1]; },
           data: {
             test: true,
             year: '<%= grunt.template.today("yyyy") %>'

--- a/docs/jade-options.md
+++ b/docs/jade-options.md
@@ -50,6 +50,8 @@ Type: `Function`
 
 This option accepts a function which takes one argument (the template filepath) and returns a string which will be used as the key for the precompiled template object.
 
+By default filepaths will be processed to a JS-friendly camelCase equivalent. (*e.g* `jade/example-file.jade` becomes `exampleFile`)
+
 **Example**
 Store all template on the default JST namespace in capital letters.
 

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -16,7 +16,15 @@ module.exports = function(grunt) {
   var defaultProcessContent = function(content) { return content; };
 
   // filename conversion for templates
-  var defaultProcessName = function(name) { return name.replace('.jade', ''); };
+  var defaultProcessName = function(name) {
+    // Remove filepath and extension (_fe/jade/cool.jade -> cool)
+    name = name.match(/([\w\.\-]*)(?=\.jade)/)[0];
+
+    // Remove "." "-" "_" characters and convert to camelCase
+    name = name.replace(/[\-\.\_]([\w])/g, function (g) { return g[1].toUpperCase(); });
+
+    return name;
+  };
 
   grunt.registerMultiTask('jade', 'Compile jade templates.', function() {
     var options = this.options({
@@ -66,7 +74,7 @@ module.exports = function(grunt) {
           } else {
             compiled = compiled(data);
           }
-          
+
           // if configured for amd and the namespace has been explicitly set
           // to false, the jade template will be directly returned
           if (options.client && options.amd && options.namespace === false) {


### PR DESCRIPTION
I rewrote the `defaultProcessName` function to be more useful. Currently the filepath is pulled into the JST template keyname, which is not very JS-friendly.

I've improved it by eliminating the filepath (it's still available to an overridden default if someone _really_ wants it) and converting filenames to camelCase.

For example: "jade/mega-widget.jade" becomes "megaWidget". Previously, the default key would be "jade/mega-widget", which is cumbersome for lookups.
