### PR TITLE
Add ability to run jade over multiple processes via `grunt.util.spawn`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
         files: {
           'tmp/jade.html': ['test/fixtures/jade.jade'],
           'tmp/jade2.html': ['test/fixtures/jade2.jade'],
+          'tmp/jadeCombine.html': ['test/fixtures/jade.jade', 'test/fixtures/jade2.jade'],
           'tmp/jadeInclude.html': ['test/fixtures/jadeInclude.jade'],
           'tmp/jadeTemplate.html': ['test/fixtures/jadeTemplate.jade']
         },
@@ -42,6 +43,38 @@ module.exports = function(grunt) {
             test: true,
             year: '<%= grunt.template.today("yyyy") %>'
           }
+        }
+      },
+
+      compile_multiprocess: {
+        files: {
+          'tmp/multiproc/jade.html': ['test/fixtures/jade.jade'],
+          'tmp/multiproc/jade2.html': ['test/fixtures/jade2.jade'],
+          'tmp/multiproc/jadeCombine.html': ['test/fixtures/jade.jade', 'test/fixtures/jade2.jade'],
+          'tmp/multiproc/jadeGlobbingCombine.html': ['test/fixtures/jadeGlobbing*.jade'],
+          'tmp/multiproc/jadeInclude.html': ['test/fixtures/jadeInclude.jade'],
+          'tmp/multiproc/jadeTemplate.html': ['test/fixtures/jadeTemplate.jade']
+        },
+        options: {
+          data: {
+            test: true,
+            year: '<%= grunt.template.today("yyyy") %>'
+          },
+          spawnProcesses: 3
+        }
+      },
+
+      compile_multiprocess_file_mapping: {
+        files: [
+          {expand:true, cwd:'test/fixtures/', src:['jade.jade'], dest:'tmp/multiproc_mapping/', ext:'.html', flatten:true},
+          {expand:true, cwd:'test/fixtures/', src:['jadeGlobbing*.jade'], dest:'tmp/multiproc_mapping/', ext:'.html', flatten:true}
+        ],
+        options: {
+          data: {
+            test: true,
+            year: '<%= grunt.template.today("yyyy") %>'
+          },
+          spawnProcesses: 2
         }
       },
 
@@ -68,6 +101,7 @@ module.exports = function(grunt) {
         files: {
           'tmp/jst/jade.js': ['test/fixtures/jade.jade'],
           'tmp/jst/jade2.js': ['test/fixtures/jade2.jade'],
+          'tmp/jst/jadeCombine.js': ['test/fixtures/jade.jade', 'test/fixtures/jade2.jade'],
           'tmp/jst/jadeInclude.js': ['test/fixtures/jadeInclude.jade'],
           'tmp/jst/jadeTemplate.js': ['test/fixtures/jadeTemplate.jade']
         },

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ define(function() {
 });
 ```
 
+#### spawnProcesses
+Type: `number`
+Default: **0**
+
+If greater than **1**, divides the Jade compilation into separate spawned tasks that execute asynchronously.
+
+
 #### processName
 Type: `Function`
 
@@ -185,4 +192,4 @@ jade: {
 
 Task submitted by [Eric Woroshow](http://ericw.ca/)
 
-*This file was generated on Thu Mar 21 2013 18:55:34.*
+*This file was generated on Tue Apr 02 2013 16:57:55.*

--- a/docs/jade-options.md
+++ b/docs/jade-options.md
@@ -45,6 +45,13 @@ define(function() {
 });
 ```
 
+## spawnProcesses
+Type: `number`
+Default: **0**
+
+If greater than **1**, divides the Jade compilation into separate spawned tasks that execute asynchronously.
+
+
 ## processName
 Type: `Function`
 

--- a/test/expected/jadeCombine.html
+++ b/test/expected/jadeCombine.html
@@ -1,0 +1,3 @@
+<div id="test" class="test"><span id="data">data</span><div>testing</div></div>
+
+<div id="test" class="test"><span id="data">data</span><div>testing 2</div></div>

--- a/test/expected/jadeGlobbingCombine.html
+++ b/test/expected/jadeGlobbingCombine.html
@@ -1,0 +1,3 @@
+<div id="test" class="test"><span id="data">data</span><div>Globbing 1</div></div>
+
+<div id="test" class="test"><span id="data">data</span><div>Globbing 2</div></div>

--- a/test/expected/jst/jadeCombine.js
+++ b/test/expected/jst/jadeCombine.js
@@ -1,0 +1,31 @@
+this["JST"] = this["JST"] || {};
+
+this["JST"]["jade"] = function anonymous(locals, attrs, escape, rethrow, merge) {
+attrs = attrs || jade.attrs; escape = escape || jade.escape; rethrow = rethrow || jade.rethrow; merge = merge || jade.merge;
+var buf = [];
+with (locals || {}) {
+var interp;
+buf.push('<div id="test" class="test"><span id="data">data</span>');
+if ( test)
+{
+buf.push('<div>testing</div>');
+}
+buf.push('</div>');
+}
+return buf.join("");
+};
+
+this["JST"]["jade2"] = function anonymous(locals, attrs, escape, rethrow, merge) {
+attrs = attrs || jade.attrs; escape = escape || jade.escape; rethrow = rethrow || jade.rethrow; merge = merge || jade.merge;
+var buf = [];
+with (locals || {}) {
+var interp;
+buf.push('<div id="test" class="test"><span id="data">data</span>');
+if ( test)
+{
+buf.push('<div>testing 2</div>');
+}
+buf.push('</div>');
+}
+return buf.join("");
+};

--- a/test/expected/multiproc_mapping/jade.html
+++ b/test/expected/multiproc_mapping/jade.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>testing</div></div>

--- a/test/expected/multiproc_mapping/jadeGlobbing1.html
+++ b/test/expected/multiproc_mapping/jadeGlobbing1.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>Globbing 1</div></div>

--- a/test/expected/multiproc_mapping/jadeGlobbing2.html
+++ b/test/expected/multiproc_mapping/jadeGlobbing2.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span><div>Globbing 2</div></div>

--- a/test/fixtures/jadeGlobbing1.jade
+++ b/test/fixtures/jadeGlobbing1.jade
@@ -1,0 +1,4 @@
+#test.test
+  span#data data
+  if test
+    div Globbing 1

--- a/test/fixtures/jadeGlobbing2.jade
+++ b/test/fixtures/jadeGlobbing2.jade
@@ -1,0 +1,4 @@
+#test.test
+  span#data data
+  if test
+    div Globbing 2

--- a/test/jade_jst_test.js
+++ b/test/jade_jst_test.js
@@ -4,7 +4,7 @@ exports.jade = {
   compile: function(test) {
     'use strict';
 
-    test.expect(4);
+    test.expect(5);
 
     var actual = grunt.file.read('tmp/jst/jade.js');
     var expected = grunt.file.read('test/expected/jst/jade.js');
@@ -13,6 +13,10 @@ exports.jade = {
     actual = grunt.file.read('tmp/jst/jade2.js');
     expected = grunt.file.read('test/expected/jst/jade2.js');
     test.equal(expected, actual, 'should compile jade templates to JST template (multiple files support)');
+
+    actual = grunt.file.read('tmp/jst/jadeCombine.js');
+    expected = grunt.file.read('test/expected/jst/jadeCombine.js');
+    test.equal(expected, actual, 'should compile jade templates to JST (multiple files support)');
 
     actual = grunt.file.read('tmp/jst/jadeInclude.js');
     expected = grunt.file.read('test/expected/jst/jadeInclude.js');

--- a/test/jade_multiproc_mapping_test.js
+++ b/test/jade_multiproc_mapping_test.js
@@ -1,0 +1,23 @@
+var grunt = require('grunt');
+
+exports.jade = {
+  compile: function(test) {
+    'use strict';
+
+    test.expect(3);
+
+    var actual = grunt.file.read('tmp/multiproc_mapping/jade.html');
+    var expected = grunt.file.read('test/expected/multiproc_mapping/jade.html');
+    test.equal(expected, actual, 'Should render from file mapping (non-globbing)');
+
+    actual = grunt.file.read('tmp/multiproc_mapping/jadeGlobbing1.html');
+    expected = grunt.file.read('test/expected/multiproc_mapping/jadeGlobbing1.html');
+    test.equal(expected, actual, 'Should render from file mapping (globbing, 1 of 2)');
+
+    actual = grunt.file.read('tmp/multiproc_mapping/jadeGlobbing2.html');
+    expected = grunt.file.read('test/expected/multiproc_mapping/jadeGlobbing2.html');
+    test.equal(expected, actual, 'Should render from file mapping (globbing, 2 of 2)');
+
+    test.done();
+  }
+};

--- a/test/jade_multiproc_test.js
+++ b/test/jade_multiproc_test.js
@@ -1,0 +1,35 @@
+var grunt = require('grunt');
+
+exports.jade = {
+  compile: function(test) {
+    'use strict';
+
+    test.expect(6);
+
+    var actual = grunt.file.read('tmp/multiproc/jade.html');
+    var expected = grunt.file.read('test/expected/jade.html');
+    test.equal(expected, actual, 'should compile jade templates to html, with multiple processes');
+
+    actual = grunt.file.read('tmp/multiproc/jade2.html');
+    expected = grunt.file.read('test/expected/jade2.html');
+    test.equal(expected, actual, 'should compile jade templates to html, with multiple processes (multiple files support)');
+
+    actual = grunt.file.read('tmp/multiproc/jadeCombine.html');
+    expected = grunt.file.read('test/expected/jadeCombine.html');
+    test.equal(expected, actual, 'should compile jade templates to html, with multiple processes, if passed an array of files');
+
+    actual = grunt.file.read('tmp/multiproc/jadeGlobbingCombine.html');
+    expected = grunt.file.read('test/expected/jadeGlobbingCombine.html');
+    test.equal(expected, actual, 'should compile jade templates to html, with multiple processes, if passed a globbing pattern');
+
+    actual = grunt.file.read('tmp/multiproc/jadeInclude.html');
+    expected = grunt.file.read('test/expected/jadeInclude.html');
+    test.equal(expected, actual, 'should compile jade templates to html with an include, and with multiple processes');
+
+    actual = grunt.file.read('tmp/multiproc/jadeTemplate.html');
+    expected = grunt.file.read('test/expected/jadeTemplate.html');
+    test.equal(expected, actual, 'should compile jade templates to html with grunt template support, and with multiple processes');
+
+    test.done();
+  }
+};

--- a/test/jade_test.js
+++ b/test/jade_test.js
@@ -4,7 +4,7 @@ exports.jade = {
   compile: function(test) {
     'use strict';
 
-    test.expect(4);
+    test.expect(5);
 
     var actual = grunt.file.read('tmp/jade.html');
     var expected = grunt.file.read('test/expected/jade.html');
@@ -12,6 +12,10 @@ exports.jade = {
 
     actual = grunt.file.read('tmp/jade2.html');
     expected = grunt.file.read('test/expected/jade2.html');
+    test.equal(expected, actual, 'should compile jade templates to html (multiple files support)');
+
+    actual = grunt.file.read('tmp/jadeCombine.html');
+    expected = grunt.file.read('test/expected/jadeCombine.html');
     test.equal(expected, actual, 'should compile jade templates to html (multiple files support)');
 
     actual = grunt.file.read('tmp/jadeInclude.html');


### PR DESCRIPTION
I've been working on a project that uses contrib-jade extensively; complex data models, medium-complex jade files. Everything's great, except the build time; as we've scaled it up the whole-project build has started to get pretty nutty.

SO, I've added the ability to break up jade tasks into separate processes, via a new `spawnProcesses` option. Works great with what we've thrown at it so far; tests have been added for various file combinations / globbing patterns.

As an example, this portion of our build has gone from this [ **72sec** ]:

![jade_before](https://f.cloud.github.com/assets/1161192/331712/028fa144-9bf9-11e2-8b04-e361d1c723f2.jpg)

to this (using six processes) [ **22sec** ]:

![jade_after](https://f.cloud.github.com/assets/1161192/331713/091ec706-9bf9-11e2-8d24-baf42cbeb4f7.jpg)

If you feel this is outside the scope of contrib-jade I'm happy to create a side-project instead, but I'd much rather it just live with the main plugin. Thanks, and yell with any issues / comments.
