### PR TITLE
If compile error, do not abort task

### DIFF
--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -75,7 +75,6 @@ module.exports = function(grunt) {
           }
         } catch (e) {
           grunt.log.error(e);
-          grunt.fail.warn('Jade failed to compile '+filepath+'.');
         }
 
         if (options.client && options.namespace !== false) {


### PR DESCRIPTION
If jade throws a compile error, any running grunt server/watch process will quit. Removing `grunt.fail` continues execution.

See [this issue](https://github.com/phated/grunt-jade/issues/14) for grunt-jade
