### PR TITLE
`files` option supported folder.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,6 +45,21 @@ module.exports = function(grunt) {
         }
       },
 
+      compile_folder: {
+        files: {
+          'tmp/folders/': ['test/fixtures/folders/']
+        }
+      },
+
+      compile_extension: {
+        files: {
+          'tmp/folders/': ['test/fixtures/folders/']
+        },
+        options: {
+          extension: 'template'
+        }
+      },
+
       compile_amd: {
         files: {
           'tmp/amd/jade.js': ['test/fixtures/jade.jade'],

--- a/test/expected/folders/jade.html
+++ b/test/expected/folders/jade.html
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span></div>

--- a/test/expected/folders/jade.template
+++ b/test/expected/folders/jade.template
@@ -1,0 +1,1 @@
+<div id="test" class="test"><span id="data">data</span></div>

--- a/test/fixtures/folders/jade.jade
+++ b/test/fixtures/folders/jade.jade
@@ -1,0 +1,2 @@
+#test.test
+  span#data data

--- a/test/jade_test.js
+++ b/test/jade_test.js
@@ -4,11 +4,19 @@ exports.jade = {
   compile: function(test) {
     'use strict';
 
-    test.expect(5);
+    test.expect(7);
 
     var actual = grunt.file.read('tmp/jade.html');
     var expected = grunt.file.read('test/expected/jade.html');
     test.equal(expected, actual, 'should compile jade templates to html');
+
+    actual = grunt.file.read('tmp/folders/jade.html');
+    expected = grunt.file.read('test/expected/folders/jade.html');
+    test.equal(expected, actual, 'should compile jade templates to html (folder support)');
+
+    actual = grunt.file.read('tmp/folders/jade.template');
+    expected = grunt.file.read('test/expected/folders/jade.template');
+    test.equal(expected, actual, 'should compile jade templates to options.extension');
 
     actual = grunt.file.read('tmp/jade2.html');
     expected = grunt.file.read('test/expected/jade2.html');


### PR DESCRIPTION
I have enabled the folder specified by the file option.

``` javascript
files: {
    'tmp/folders/': ['test/fixtures/folders/']
}
```

result...

```
test/fixtures/folders/
└── jade.jade
tmp/folders/
└── jade.html
```

and customize file extension.

`extension: template` ...

```
files: {
    `tmp/folders/': ['test/fixtures/folders/']
},
options: {
    extension: 'template'
}
```

result...

```
test/fixtures/folders/
└── jade.jade
tmp/folders/
└── jade.template
```

Thanks.
