### PR TITLE
Update Jade to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jade": "~0.35.0",
+    "jade": "~1.0.0",
     "grunt-lib-contrib": "~0.6.1"
   },
   "devDependencies": {

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -68,10 +68,10 @@ module.exports = function(grunt) {
           compiled = jade.compile(src, options);
           // if in client mode, return function source
           if (options.client) {
-            compiled = compiled.toString();
+            compiled = jade.compileClient(src, options).toString();
           } else {
             // if data is function, bind to f.orig, passing f.dest and f.src
-            compiled = compiled(f.orig.data);
+            compiled = jade.compile(src, options)(f.orig.data);
           }
           
           // if configured for amd and the namespace has been explicitly set

--- a/test/expected/amd/jade.js
+++ b/test/expected/amd/jade.js
@@ -1,7 +1,8 @@
 define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { jade = jade.runtime; }
 
-return function anonymous(locals) {
+return function template(locals) {
 var buf = [];
+var jade_mixins = {};
 var locals_ = (locals || {}),test = locals_.test;buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
 if ( test)
 {

--- a/test/expected/amd/jade2.js
+++ b/test/expected/amd/jade2.js
@@ -1,7 +1,8 @@
 define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { jade = jade.runtime; }
 
-return function anonymous(locals) {
+return function template(locals) {
 var buf = [];
+var jade_mixins = {};
 var locals_ = (locals || {}),test = locals_.test;buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
 if ( test)
 {

--- a/test/expected/amd/jadeInclude.js
+++ b/test/expected/amd/jadeInclude.js
@@ -1,7 +1,8 @@
 define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { jade = jade.runtime; }
 
-return function anonymous(locals) {
+return function template(locals) {
 var buf = [];
+var jade_mixins = {};
 buf.push("<html><head><title>TEST</title></head><body></body></html>");
 var a = 'hello jade test'
 buf.push("<p>" + (jade.escape(null == (jade.interp = a) ? "" : jade.interp)) + "</p>");;return buf.join("");

--- a/test/expected/amd/jadeTemplate.js
+++ b/test/expected/amd/jadeTemplate.js
@@ -1,7 +1,8 @@
 define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { jade = jade.runtime; }
 
-return function anonymous(locals) {
+return function template(locals) {
 var buf = [];
+var jade_mixins = {};
 var locals_ = (locals || {}),year = locals_.year;buf.push("<div>" + (jade.escape(null == (jade.interp = year) ? "" : jade.interp)) + "</div>");;return buf.join("");
 }
 

--- a/test/expected/jst/jade.js
+++ b/test/expected/jst/jade.js
@@ -1,7 +1,8 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["jade"] = function anonymous(locals) {
+this["JST"]["jade"] = function template(locals) {
 var buf = [];
+var jade_mixins = {};
 var locals_ = (locals || {}),test = locals_.test;buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
 if ( test)
 {

--- a/test/expected/jst/jade2.js
+++ b/test/expected/jst/jade2.js
@@ -1,7 +1,8 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["jade2"] = function anonymous(locals) {
+this["JST"]["jade2"] = function template(locals) {
 var buf = [];
+var jade_mixins = {};
 var locals_ = (locals || {}),test = locals_.test;buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
 if ( test)
 {

--- a/test/expected/jst/jadeInclude.js
+++ b/test/expected/jst/jadeInclude.js
@@ -1,7 +1,8 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["jadeInclude"] = function anonymous(locals) {
+this["JST"]["jadeInclude"] = function template(locals) {
 var buf = [];
+var jade_mixins = {};
 buf.push("<html><head><title>TEST</title></head><body></body></html>");
 var a = 'hello jade test'
 buf.push("<p>" + (jade.escape(null == (jade.interp = a) ? "" : jade.interp)) + "</p>");;return buf.join("");

--- a/test/expected/jst/jadeTemplate.js
+++ b/test/expected/jst/jadeTemplate.js
@@ -1,6 +1,7 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["jadeTemplate"] = function anonymous(locals) {
+this["JST"]["jadeTemplate"] = function template(locals) {
 var buf = [];
+var jade_mixins = {};
 var locals_ = (locals || {}),year = locals_.year;buf.push("<div>" + (jade.escape(null == (jade.interp = year) ? "" : jade.interp)) + "</div>");;return buf.join("");
 };


### PR DESCRIPTION
Compiling client templates now uses `jade.compileClient` instead of the `client` option.

Also, the client code generated by Jade differs slightly so the tests have been updated to reflect this.
