### PR TITLE
Add main property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "url": "https://github.com/gruntjs/grunt-contrib-jade/blob/master/LICENSE-MIT"
     }
   ],
+  "main": "tasks/jade",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
The `main` option is required when try to resolve and require a module via node.js.
I have some grunt tasks which uses another tasks as module dependency.

In 0.9.0 I can't resolve the module using `require.resolve()` because this property is missing and the node resolve algorithm only support an unique entry point to the module defined by this property

Please, merge it! Thanks :-)
