### PR TITLE
Use chalk module to colorize terminal output

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "jade": "~1.0.2",
     "grunt-lib-contrib": "~0.6.1",
-    "lodash-node": "~2.4.1"
+    "lodash-node": "~2.4.1",
+    "chalk": "~0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.8.0",

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -11,6 +11,7 @@
 module.exports = function(grunt) {
   var _ = require('lodash-node/modern/objects');
   var helpers = require('grunt-lib-contrib').init(grunt);
+  var chalk = require('chalk');
 
   // content conversion for templates
   var defaultProcessContent = function(content) { return content; };
@@ -80,7 +81,7 @@ module.exports = function(grunt) {
             compiled = 'return ' + compiled;
           }
         } catch (e) {
-          grunt.log.warn('Jade failed to compile ' + filepath + '.');
+          grunt.log.warn('Jade failed to compile "' + filepath + '".');
           grunt.log.error(e);
           return false;
         }
@@ -121,7 +122,7 @@ module.exports = function(grunt) {
         }
 
         grunt.file.write(f.dest, output.join(grunt.util.normalizelf(options.separator)));
-        grunt.log.writeln('File "' + f.dest + '" created.');
+        grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created.');
       }
     });
 


### PR DESCRIPTION
- Add [chalk](https://github.com/sindresorhus/chalk) as a dependency and use it to colorize terminal output.
- Add quotes around the filepath in the message string logged when compilation fails (consistency).
