### PR TITLE
Add option replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,16 +121,17 @@ The namespace in which the precompiled templates will be assigned. Use dot notat
 
 When set to `false` with **amd** option set to `true`, the templates will be returned directly from the AMD wrapper.
 
-#### rewrite_path
-Type: `function`
+#### replace
+Type: `Object`
 Default: **false**
 
-The rewrite_path can be used when your application uses the namespace option above.
-It's useful for modifying the final name used for the template, beneath your namespace.
+Can be used with the *namespace* option to make any number of
+replacements on the template namespace.
 
 ```javascript
-rewrite_path: function(name){
-  return name.replace('app/templates/','').replace('/', '_');
+replace: {
+  'app/templates/':'', // remove the leading path
+  '/':'_' // use _ instead of / for templates nested in folders 
 }
 ```
 

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -86,10 +86,12 @@ module.exports = function(grunt) {
         }
 
         if (options.client && options.namespace !== false) {
-          if (typeof options.rewrite_path === "function")
-            templates.push(nsInfo.namespace+'['+options.rewrite_path(JSON.stringify(filename))+'] = '+compiled+';');
-          else
-            templates.push(nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+';');
+          if (typeof options.replace === "object") {
+            Object.keys(options.replace).forEach(function(key){
+              filename = filename.replace(key, options.replace[key]);
+            });
+          }
+          templates.push(nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+';');
         } else {
           templates.push(compiled);
         }


### PR DESCRIPTION
Hi, we've modified this plugin slightly to accept an option called 'replace'. I've documented it and here's how we're using it in our actual gruntfile:

``` javascript
jade: {
  templates: {
    options: {
      client: true,
      namespace: 'App.Templates',
      replace: {
        'app/templates/':'',
        '/':'_'
      }
    },
    files: {
      'public/js/templates.js': [ 'app/templates/**/*.jade' ]
    }
  }
}
```

This was a simple way to override the final namespacing to accommodate our convention prior to switching to grunt. Thanks!
