### PR TITLE
Fix redundant compilation / Remove lodash-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,11 @@
   "dependencies": {
     "jade": "~1.1.5",
     "grunt-lib-contrib": "~0.6.1",
-    "lodash-node": "~2.4.1",
     "chalk": "~0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-nodeunit": "~0.2.2",
+    "grunt-contrib-nodeunit": "~0.3.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-internal": "~0.4.6",
     "grunt": "~0.4.2"

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -9,7 +9,6 @@
 'use strict';
 
 module.exports = function(grunt) {
-  var _ = require('lodash-node/modern/objects');
   var helpers = require('grunt-lib-contrib').init(grunt);
   var chalk = require('chalk');
 
@@ -56,22 +55,25 @@ module.exports = function(grunt) {
         var compiled, filename;
         filename = processName(filepath);
 
-        options = _.assign(options, { filename: filepath });
+        options.filename = filepath;
 
         try {
           var jade = f.orig.jade = require('jade');
-          f.orig.data = _.isFunction(data) ? data.call(f.orig, f.dest, f.src) : data;
+          if (typeof data === 'function') {
+            // if data is function, bind to f.orig, passing f.dest and f.src
+            f.orig.data = data.call(f.orig, f.dest, f.src);
+          } else {
+            f.orig.data = data;
+          }
           if (options.filters) {
             Object.keys(options.filters).forEach(function(filter) {
               jade.filters[filter] = options.filters[filter].bind(f.orig);
             });
           }
-          compiled = jade.compile(src, options);
           // if in client mode, return function source
           if (options.client) {
             compiled = jade.compileClient(src, options).toString();
           } else {
-            // if data is function, bind to f.orig, passing f.dest and f.src
             compiled = jade.compile(src, options)(f.orig.data);
           }
 


### PR DESCRIPTION
- Currently this plugin compiles each Jade file twice. So I fixed it.
- I removed [lodash-node](https://github.com/lodash/lodash-node) module from dependencies because it's substitutable with vanilla JavaScript in this case.
