### PR TITLE
Support jade 1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jade": "~1.1.5",
+    "jade": "~1.2.0",
     "grunt-lib-contrib": "~0.6.1",
     "chalk": "~0.4.0"
   },

--- a/test/expected/amd/jade.js
+++ b/test/expected/amd/jade.js
@@ -3,6 +3,7 @@ define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { ja
 return function template(locals) {
 var buf = [];
 var jade_mixins = {};
+var jade_interp;
 var locals_ = (locals || {}),test = locals_.test;
 buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
 if ( test)

--- a/test/expected/amd/jade2.js
+++ b/test/expected/amd/jade2.js
@@ -3,6 +3,7 @@ define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { ja
 return function template(locals) {
 var buf = [];
 var jade_mixins = {};
+var jade_interp;
 var locals_ = (locals || {}),test = locals_.test;
 buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
 if ( test)

--- a/test/expected/amd/jadeInclude.js
+++ b/test/expected/amd/jadeInclude.js
@@ -3,10 +3,11 @@ define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { ja
 return function template(locals) {
 var buf = [];
 var jade_mixins = {};
+var jade_interp;
 
 buf.push("<html><head><title>TEST</title></head><body></body></html>");
 var a = 'hello jade test'
-buf.push("<p>" + (jade.escape(null == (jade.interp = a) ? "" : jade.interp)) + "</p>");;return buf.join("");
+buf.push("<p>" + (jade.escape(null == (jade_interp = a) ? "" : jade_interp)) + "</p>");;return buf.join("");
 }
 
 });

--- a/test/expected/amd/jadeTemplate.js
+++ b/test/expected/amd/jadeTemplate.js
@@ -3,8 +3,9 @@ define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { ja
 return function template(locals) {
 var buf = [];
 var jade_mixins = {};
+var jade_interp;
 var locals_ = (locals || {}),year = locals_.year;
-buf.push("<div>" + (jade.escape(null == (jade.interp = year) ? "" : jade.interp)) + "</div>");;return buf.join("");
+buf.push("<div>" + (jade.escape(null == (jade_interp = year) ? "" : jade_interp)) + "</div>");;return buf.join("");
 }
 
 });

--- a/test/expected/jst/jade.js
+++ b/test/expected/jst/jade.js
@@ -3,6 +3,7 @@ this["JST"] = this["JST"] || {};
 this["JST"]["jade"] = function template(locals) {
 var buf = [];
 var jade_mixins = {};
+var jade_interp;
 var locals_ = (locals || {}),test = locals_.test;
 buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
 if ( test)

--- a/test/expected/jst/jade2.js
+++ b/test/expected/jst/jade2.js
@@ -3,6 +3,7 @@ this["JST"] = this["JST"] || {};
 this["JST"]["jade2"] = function template(locals) {
 var buf = [];
 var jade_mixins = {};
+var jade_interp;
 var locals_ = (locals || {}),test = locals_.test;
 buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
 if ( test)

--- a/test/expected/jst/jadeInclude.js
+++ b/test/expected/jst/jadeInclude.js
@@ -3,8 +3,9 @@ this["JST"] = this["JST"] || {};
 this["JST"]["jadeInclude"] = function template(locals) {
 var buf = [];
 var jade_mixins = {};
+var jade_interp;
 
 buf.push("<html><head><title>TEST</title></head><body></body></html>");
 var a = 'hello jade test'
-buf.push("<p>" + (jade.escape(null == (jade.interp = a) ? "" : jade.interp)) + "</p>");;return buf.join("");
+buf.push("<p>" + (jade.escape(null == (jade_interp = a) ? "" : jade_interp)) + "</p>");;return buf.join("");
 };

--- a/test/expected/jst/jadeTemplate.js
+++ b/test/expected/jst/jadeTemplate.js
@@ -3,6 +3,7 @@ this["JST"] = this["JST"] || {};
 this["JST"]["jadeTemplate"] = function template(locals) {
 var buf = [];
 var jade_mixins = {};
+var jade_interp;
 var locals_ = (locals || {}),year = locals_.year;
-buf.push("<div>" + (jade.escape(null == (jade.interp = year) ? "" : jade.interp)) + "</div>");;return buf.join("");
+buf.push("<div>" + (jade.escape(null == (jade_interp = year) ? "" : jade_interp)) + "</div>");;return buf.join("");
 };


### PR DESCRIPTION
Looks like jade.interp changed to a function scope variable, jade_interp.
