### PR TITLE
made jade a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jade": "~1.2.0",
     "grunt-lib-contrib": "~0.6.1",
     "chalk": "~0.4.0"
   },
@@ -39,6 +38,7 @@
     "grunt": "~0.4.2"
   },
   "peerDependencies": {
+    "jade": ">1.2.0",
     "grunt": "~0.4.1"
   },
   "keywords": [


### PR DESCRIPTION
in order to use the same jade version during tests as during production
