### PR TITLE
Make jade task to fail on an error

### DIFF
--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -83,8 +83,8 @@ module.exports = function(grunt) {
             compiled = 'return ' + compiled;
           }
         } catch (e) {
-          grunt.log.warn('Jade failed to compile "' + filepath + '".');
           grunt.log.error(e);
+          grunt.fail.warn('Jade failed to compile "' + filepath + '".');
           return false;
         }
 


### PR DESCRIPTION
I think it would be better to see the task to fail when there is an
error. This is a must have for integration tools.

Best,
David
