### PR TITLE
Update dependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jade": "~1.3.0",
-    "chalk": "~0.4.0"
+    "jade": "~1.6.0",
+    "chalk": "~0.5.1"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-nodeunit": "~0.3.0",
-    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-internal": "~0.4.6",
     "grunt": "~0.4.2"
   },


### PR DESCRIPTION
[Jade](https://github.com/visionmedia/jade) is now [v1.6.0](https://github.com/visionmedia/jade/blob/master/History.md#160--2014-08-31).
