### PR TITLE
Default data to "{}"

### DIFF
--- a/tasks/pug.js
+++ b/tasks/pug.js
@@ -66,7 +66,8 @@ module.exports = function(grunt) {
             // if data is function, bind to f.orig, passing f.dest and f.src
             f.orig.data = data.call(f.orig, f.dest, f.src);
           } else {
-            f.orig.data = data;
+            // Defaults data to an empty object {}
+            f.orig.data = data || {};
           }
           if (options.filters) {
             if (!f.orig.data.filters) {


### PR DESCRIPTION
Defaults the data to {} so later we can access it as an object. Fixes https://github.com/gruntjs/grunt-contrib-pug/issues/168